### PR TITLE
cffi:*foreign-library-directories* is not a list of strings any more

### DIFF
--- a/cudd-cffi.i
+++ b/cudd-cffi.i
@@ -138,8 +138,7 @@
 
 (let ((libdir "/opt/local/lib/cudd/"))
   (when (probe-file libdir)
-    (pushnew libdir cffi:*foreign-library-directories* :test #'string=)))
-                
+    (pushnew libdir cffi:*foreign-library-directories* :test #'equal)))
 
 (cffi:use-foreign-library libcudd)
 

--- a/cuddapi.lisp
+++ b/cuddapi.lisp
@@ -159,8 +159,7 @@
 
 (let ((libdir "/opt/local/lib/cudd/"))
   (when (probe-file libdir)
-    (pushnew libdir cffi:*foreign-library-directories* :test #'string=)))
-                
+    (pushnew libdir cffi:*foreign-library-directories* :test #'equal)))
 
 (cffi:use-foreign-library libcudd)
 


### PR DESCRIPTION
`cffi:*foreign-library-directories*` is not a list of strings any more, I got an error when `PUSHNEW` uses `#'STRING=` as test functions.